### PR TITLE
Add files backup option in search results

### DIFF
--- a/Symfony/app/config/services.yml
+++ b/Symfony/app/config/services.yml
@@ -10,7 +10,7 @@ services:
         arguments: ["@doctrine.orm.entity_manager", "@logger", "@vbee.manager.setting"]
     pde.teammanager:
         class: PDEBundle\Teams\TeamManager
-        arguments: ["@doctrine.orm.entity_manager", "@pde.directory.handler", "@logger", "@vbee.manager.setting"]
+        arguments: ["@doctrine.orm.entity_manager", "@pde.directory.handler", "@pde.file.handler", "@logger", "@vbee.manager.setting"]
     pde.usermanager:
         class: PDEBundle\Users\UserManager
         arguments: ["@doctrine.orm.entity_manager"]

--- a/Symfony/src/PDEBundle/Resources/views/Search/search_result.html.twig
+++ b/Symfony/src/PDEBundle/Resources/views/Search/search_result.html.twig
@@ -3,7 +3,7 @@
         Team {{ team.id }} - <small>created at {{ team.created | date("Y-M-d") }} </small>
     </h3>
     <div class="row">
-        <div class="col-md-8">
+        <div class="col-md-6">
             <p class="list-group-item-text"><b>Members:</b></p>
             <ul class="email-list">
                 {% for member in team.members  %}
@@ -11,8 +11,9 @@
                 {% endfor %}
             </ul>
         </div>
-        <div class="col-md-4">
-            <a href="{{ path('admin_editor', {'team' : team.id}) }}" target="_blank" class="btn btn-default team-editor-link">Jump to team editor</a>
+        <div class="col-md-6">
+            <a href="{{ path('admin_editor', {'team' : team.id}) }}" target="_blank" class="btn btn-default team-editor-link">Go to team editor</a>
+            <a href="{{ path('admin_team_backup', {'team' : team.id}) }}" target="_blank" class="btn btn-default team-editor-link"><i class="fa fa-download"></i> Backup workspaces</a>
             <a data-team-id="{{ team.id }}" class="btn btn-danger delete-team-btn team-editor-link"> <i class="fa fa-trash-o"></i> Delete team</a>
         </div>
     </div>

--- a/Symfony/src/PDEBundle/Teams/TeamManager.php
+++ b/Symfony/src/PDEBundle/Teams/TeamManager.php
@@ -7,6 +7,7 @@ use Monolog\Logger;
 use PDEBundle\Entity\User;
 use PDEBundle\Entity\Team;
 use PDEBundle\FileSystemHandler\DirectoryHandler;
+use PDEBundle\FileSystemHandler\FileHandler;
 use VBee\SettingBundle\Manager\SettingDoctrineManager;
 
 /**
@@ -23,6 +24,9 @@ class TeamManager
     /** @var DirectoryHandler $directoryHandler */
     private $directoryHandler;
 
+    /** @var FileHandler $fileHandler */
+    private $fileHandler;
+
     /** @var Logger $logger */
     private $logger;
 
@@ -37,6 +41,7 @@ class TeamManager
      *
      * @param EntityManager $entityManager
      * @param DirectoryHandler $directoryHandler
+     * @param FileHandler $fileHandler
      * @param Logger $logger
      * @param SettingDoctrineManager $settingsManager
      * @throws \ErrorException
@@ -44,12 +49,14 @@ class TeamManager
     public function __construct(
         EntityManager $entityManager,
         DirectoryHandler $directoryHandler,
+        FileHandler $fileHandler,
         Logger $logger,
         SettingDoctrineManager $settingsManager
     )
     {
         $this->entityManager = $entityManager;
         $this->directoryHandler = $directoryHandler;
+        $this->fileHandler = $fileHandler;
         $this->logger = $logger;
         $storageRoot = $settingsManager->get('storage_root');
         // Create the directory if it does not already exist
@@ -171,5 +178,58 @@ class TeamManager
         }
 
         return ['success' => true];
+    }
+
+    /**
+     * Returns a zip archive containing the specified team's workspaces and their files.
+     *
+     * @param Team $team
+     * @return array
+     */
+    public function zipTeamFolder(Team $team)
+    {
+        // Create the zip name from the team members' usernames
+        $zipName = '';
+        $teamMembers = $team->getMembers();
+        foreach ($teamMembers as $user) {
+            /** @var User $user */
+            $zipName .= $user->getUsername() . '_';
+        }
+
+        // Gather all the team's workspaces
+        $teamFolder = $team->getTeamFolder();
+        $directories = $this->directoryHandler->getSubdiretoriesList($teamFolder);
+        if ($directories['success'] !== true) {
+            return $directories;
+        }
+
+        $workspaces = [];
+        foreach ($directories['list'] as $workspace) {
+            // Get the files of the workspace (base-64 encoded)
+            $files = $this->directoryHandler->getFilesContents($teamFolder . DIRECTORY_SEPARATOR . $workspace);
+            if ($files['success'] !== true) {
+                return $files;
+            }
+            $workspaces[] = $files['contents'];
+        }
+
+        // Then create an assoc array with the files (names contains parent directory too)
+        $zipFiles = [];
+        foreach ($workspaces as $workspace) {
+            foreach ($workspace['files'] as $file) {
+                $zipFiles[] = [
+                    'filename' => $workspace['name'] . DIRECTORY_SEPARATOR . $file['filename'],
+                    'content' => $file['content']
+                ];
+            }
+        }
+
+        // Last step, zip the files
+        $zipCreationResult = $this->fileHandler->createZipFromFiles($zipName, $zipFiles);
+        if ($zipCreationResult['success'] !== true) {
+            return ['success' => false, 'error' => 'Failed to create zip archive with the team\'s workspaces.'];
+        }
+
+        return $zipCreationResult;
     }
 }


### PR DESCRIPTION
This PR allows admins to create zip archive backups of a team's workspaces from the search results page. Returns a zip archive named after the usernames of the team's members.
Binary file contents that might exist in workspaces are preserved. 